### PR TITLE
[#488067126] Create Signin through registration_id

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1795,7 +1795,7 @@ paths:
                                     email: some text
                             With Registration ID:
                                 value:
-                                    registration_id: '1234567'
+                                    registration_id: '123531144'
                                     guest_email_template_id: 47
                                     host_email_template_id: 65
                                     send_notifications: true
@@ -3039,43 +3039,18 @@ paths:
                                         email: some text
                                         company: some text
                                         photo_url: some text
-                                        guest_reponses:
-                                            -
-                                                title: some text
-                                                sequence: 9
-                                                id: 46
-                                                page_type: some text
-                                                custom_fields:
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
-                                            -
-                                                title: some text
-                                                sequence: 8
-                                                id: 22
-                                                page_type: some text
-                                                custom_fields:
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
                                         invite:
-                                            id: 96
+                                            id: 67
                                             first_name: some text
                                             last_name: some text
                                             start_date: '2018-02-10T09:30Z'
                                             location:
-                                                id: 95
+                                                id: 22
                                                 name: some text
                                             watchlist_colour: GREEN
                                             hosts:
                                                 -
-                                                    id: 61
+                                                    id: 59
                                                     email: some text
                                                     first_name: some text
                                                     last_name: some text
@@ -3083,7 +3058,7 @@ paths:
                                                     department: some text
                                                     mobile_number: some text
                                                 -
-                                                    id: 57
+                                                    id: 18
                                                     email: some text
                                                     first_name: some text
                                                     last_name: some text
@@ -3091,7 +3066,7 @@ paths:
                                                     department: some text
                                                     mobile_number: some text
                                             invite_watchlist:
-                                                id: 7
+                                                id: 65
                                                 external_colours:
                                                     - some text
                                                     - some text
@@ -3102,7 +3077,7 @@ paths:
                                             email: some text
                                             mobile_number: some text
                                         visitor:
-                                            id: 7
+                                            id: some text
                                             active: true
                                             company: some text
                                             created_via: some text
@@ -3118,6 +3093,31 @@ paths:
                                             watchlist_level: some text
                                             created_at: '2018-02-10T09:30Z'
                                             updated_at: '2018-02-10T09:30Z'
+                                        guest_responses:
+                                            -
+                                                title: some text
+                                                sequence: 17
+                                                id: some text
+                                                page_type: branch_page
+                                                custom_fields:
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
+                                            -
+                                                title: some text
+                                                sequence: 29
+                                                id: some text
+                                                page_type: docusign_page
+                                                custom_fields:
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
                     description: Successful response - returns a single `Registration`.
                 '400':
                     content:
@@ -5728,17 +5728,17 @@ components:
                 photo_url:
                     description: URL of the uploaded photo
                     type: string
-                guest_reponses:
-                    description: Response given by the guest
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/GuestResponse'
                 invite:
                     $ref: '#/components/schemas/Invite'
                     description: Invite it belongs to
                 visitor:
                     $ref: '#/components/schemas/Visitor'
                     description: Visitor
+                guest_responses:
+                    description: Response given by the guest
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GuestResponse'
             example:
                 id: uuid
                 created_at: '2018-02-10T09:30Z'
@@ -5746,43 +5746,18 @@ components:
                 email: some text
                 company: some text
                 photo_url: some text
-                guest_reponses:
-                    -
-                        title: some text
-                        sequence: 69
-                        id: 36
-                        page_type: some text
-                        custom_fields:
-                            -
-                                field_name: some text
-                                field_value: some text
-                            -
-                                field_name: some text
-                                field_value: some text
-                    -
-                        title: some text
-                        sequence: 64
-                        id: 20
-                        page_type: some text
-                        custom_fields:
-                            -
-                                field_name: some text
-                                field_value: some text
-                            -
-                                field_name: some text
-                                field_value: some text
                 invite:
-                    id: 39
+                    id: 51
                     first_name: some text
                     last_name: some text
                     start_date: '2018-02-10T09:30Z'
                     location:
-                        id: 21
+                        id: 67
                         name: some text
-                    watchlist_colour: GREEN
+                    watchlist_colour: YELLOW
                     hosts:
                         -
-                            id: 16
+                            id: 23
                             email: some text
                             first_name: some text
                             last_name: some text
@@ -5790,7 +5765,7 @@ components:
                             department: some text
                             mobile_number: some text
                         -
-                            id: 92
+                            id: 23
                             email: some text
                             first_name: some text
                             last_name: some text
@@ -5798,7 +5773,7 @@ components:
                             department: some text
                             mobile_number: some text
                     invite_watchlist:
-                        id: 91
+                        id: 70
                         external_colours:
                             - some text
                             - some text
@@ -5809,7 +5784,7 @@ components:
                     email: some text
                     mobile_number: some text
                 visitor:
-                    id: 20
+                    id: some text
                     active: true
                     company: some text
                     created_via: some text
@@ -5825,6 +5800,31 @@ components:
                     watchlist_level: some text
                     created_at: '2018-02-10T09:30Z'
                     updated_at: '2018-02-10T09:30Z'
+                guest_responses:
+                    -
+                        title: some text
+                        sequence: 43
+                        id: some text
+                        page_type: video_page
+                        custom_fields:
+                            -
+                                field_name: some text
+                                field_value: some text
+                            -
+                                field_name: some text
+                                field_value: some text
+                    -
+                        title: some text
+                        sequence: 35
+                        id: some text
+                        page_type: guest_sign_page
+                        custom_fields:
+                            -
+                                field_name: some text
+                                field_value: some text
+                            -
+                                field_name: some text
+                                field_value: some text
         GuestResponse:
             title: Root Type for GuestResponse
             description: The data collected from the response on a Registration

--- a/openapi.yml
+++ b/openapi.yml
@@ -4455,8 +4455,7 @@ components:
                                 - some text
                         end_date: '2018-02-10T09:30Z'
         SigninCreateParams:
-            required:
-                - location_id
+            required: []
             type: object
             properties:
                 guest_email_template_id:
@@ -4464,22 +4463,28 @@ components:
                 host_email_template_id:
                     type: integer
                 host_ids:
+                    description: 'Array of Hosts, ignored if `registration_id` is included'
                     type: array
                     items:
                         type: integer
                 location_id:
+                    description: 'ID of the Location where the Signin happened, ignored if `registration_id` is included'
                     type: integer
                 send_notifications:
                     type: boolean
                 sms_message:
                     type: string
                 first_name:
+                    description: 'First name, ignored if `registration_id` is included'
                     type: string
                 last_name:
+                    description: 'Last name, ignored if `registration_id` is included'
                     type: string
                 company:
+                    description: 'Company name, ignored if `registration_id` is included'
                     type: string
                 email:
+                    description: 'E-mail, ignored if `registration_id` is included'
                     type: string
                 registration_id:
                     description: UUID of a Registration

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
     title: Traction Guest API
-    version: 0.11.1
+    version: 0.11.0
     description: 'A compelling story about a lone device, on a quest for its data.'
     contact:
         name: Brandon McKay
@@ -1806,13 +1806,6 @@ paths:
             parameters:
                 -
                     $ref: '#/components/parameters/idempotencyKey'
-                -
-                    name: registration_id
-                    description: UUID of a Registration
-                    schema:
-                        type: string
-                    in: query
-                    required: false
             responses:
                 '201':
                     content:

--- a/openapi.yml
+++ b/openapi.yml
@@ -4481,6 +4481,9 @@ components:
                     type: string
                 email:
                     type: string
+                registration_id:
+                    description: UUID of a Registration
+                    type: string
             example:
                 guest_email_template_id: 60
                 host_email_template_id: 50

--- a/openapi.yml
+++ b/openapi.yml
@@ -1795,7 +1795,7 @@ paths:
                                     email: some text
                             With Registration ID:
                                 value:
-                                    registration_id: '123531144'
+                                    registration_id: '1234567'
                                     guest_email_template_id: 47
                                     host_email_template_id: 65
                                     send_notifications: true

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
     title: Traction Guest API
-    version: 0.11.0
+    version: 0.11.1
     description: 'A compelling story about a lone device, on a quest for its data.'
     contact:
         name: Brandon McKay

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
     title: Traction Guest API
-    version: 0.11.0
+    version: 0.11.1
     description: 'A compelling story about a lone device, on a quest for its data.'
     contact:
         name: Brandon McKay
@@ -1793,12 +1793,26 @@ paths:
                                     last_name: some text
                                     company: some text
                                     email: some text
+                            With Registration ID:
+                                value:
+                                    registration_id: '123531144'
+                                    guest_email_template_id: 47
+                                    host_email_template_id: 65
+                                    send_notifications: true
+                                    sms_message: some text
                 required: true
             tags:
                 - Signins
             parameters:
                 -
                     $ref: '#/components/parameters/idempotencyKey'
+                -
+                    name: registration_id
+                    description: UUID of a Registration
+                    schema:
+                        type: string
+                    in: query
+                    required: false
             responses:
                 '201':
                     content:
@@ -3175,9 +3189,9 @@ paths:
             security:
                 -
                     TractionGuestAuth:
-                      - all
-                      - 'signin:*'
-                      - 'signin:read'
+                        - all
+                        - 'signin:*'
+                        - 'signin:read'
             operationId: getRegistration
             summary: Get a Registration
             description: Gets the details of a single instance of a `Registration`

--- a/openapi.yml
+++ b/openapi.yml
@@ -1793,9 +1793,9 @@ paths:
                                     last_name: some text
                                     company: some text
                                     email: some text
-                            With Registration ID:
+                            with_registration:
                                 value:
-                                    registration_id: '123531144'
+                                    registration_id: uuid
                                     guest_email_template_id: 47
                                     host_email_template_id: 65
                                     send_notifications: true
@@ -4455,6 +4455,7 @@ components:
                                 - some text
                         end_date: '2018-02-10T09:30Z'
         SigninCreateParams:
+            description: Params used to create a Signin
             required: []
             type: object
             properties:
@@ -4463,7 +4464,7 @@ components:
                 host_email_template_id:
                     type: integer
                 host_ids:
-                    description: 'Array of Hosts, ignored if `registration_id` is included'
+                    description: 'Array of Host ids, ignored if `registration_id` is included'
                     type: array
                     items:
                         type: integer
@@ -4471,6 +4472,7 @@ components:
                     description: 'ID of the Location where the Signin happened, ignored if `registration_id` is included'
                     type: integer
                 send_notifications:
+                    description: Should send notification to host/guests?
                     type: boolean
                 sms_message:
                     type: string


### PR DESCRIPTION
### Wrike: ###
Create V3 Signin through registration id
https://www.wrike.com/open.htm?id=488067126

### Description: ###

So ultimately I would have two ways to create a sign in

1. the “normal” way, by providing first name, last name, email, company, etc. which looks something like this:
```
{
   “guest_email_template_id”: 47,
   “host_email_template_id”: 65,
   “host_ids”: [
       77,
       49
   ],
   “location_id”: 79,
   “send_notifications”: true,
   “photos”: [
       {},
       {}
   ],
   “sms_message”: “some text”,
   “first_name”: “some text”,
   “last_name”: “some text”,
   “company”: “some text”,
   “email”: “some text”
}
```

2. with a registration id.
If we can compare it to the above example, we would replace the first name, last name, photos, company, email, host ids, and location id
params with a registration id
Everything else should stay the same. Right now we have a “send notifications” boolean, which seems kind of redundant to me but I suppose it should be a parameter to keep it consistent with the existing one
It would look something like this:
```
{
   "registration_id": 123531144,
   "guest_email_template_id": 47,
   "host_email_template_id": 65,
   "send_notifications": true,
   "sms_message": "some text"
}
```
### PR Checklist ###

- [ ] Assigned 2 or more reviewers
- [x] Added yourself as "Assignee"
- [x] Included labels such as "WIP", "Waiting for reviews", etc.
