### PR TITLE
[#493269014] Return external and internal on invite_watchlist

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -5130,11 +5130,12 @@ components:
                     format: int32
                     type: integer
                 external_colours:
-                    description: ''
+                    description: Deprecated
                     type: array
                     items:
                         type: string
                 internal_colours:
+                    description: Deprecated
                     type: array
                     items:
                         type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
     title: Traction Guest API
-    version: 0.11.1
+    version: 0.11.2
     description: 'A compelling story about a lone device, on a quest for its data.'
     contact:
         name: Brandon McKay
@@ -1226,76 +1226,657 @@ paths:
                                 default:
                                     value:
                                         pagination:
-                                            total_records: 44
-                                            current_offset: 89
-                                            next_offset: 51
+                                            total_records: 89
+                                            current_offset: 72
+                                            next_offset: 29
+                                            last_id: 49
                                         invites:
                                             -
-                                                id: 69
+                                                id: 37
                                                 first_name: some text
                                                 last_name: some text
                                                 start_date: '2018-02-10T09:30Z'
                                                 location:
-                                                    id: 93
+                                                    id: 70
                                                     name: some text
-                                                watchlist_colour: GREEN
+                                                watchlist_colour: RED
                                                 hosts:
                                                     -
-                                                        id: 55
+                                                        id: 78
                                                         email: some text
                                                         first_name: some text
                                                         last_name: some text
-                                                        mobile_number: some text
                                                         profile_pic_url: some text
+                                                        department: some text
+                                                        mobile_number: some text
                                                     -
-                                                        id: 32
+                                                        id: 41
                                                         email: some text
                                                         first_name: some text
                                                         last_name: some text
-                                                        mobile_number: some text
                                                         profile_pic_url: some text
+                                                        department: some text
+                                                        mobile_number: some text
                                                 invite_watchlist:
-                                                    id: 22
+                                                    id: 61
                                                     external_colours:
+                                                        - some text
                                                         - some text
                                                     internal_colours:
                                                         - some text
                                                         - some text
+                                                    external:
+                                                        -
+                                                            search_terms:
+                                                                name: some text
+                                                                company: some text
+                                                                city: some text
+                                                                country: some text
+                                                                state: some text
+                                                            integration: some text
+                                                            colour: YELLOW
+                                                            matches:
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                        -
+                                                            search_terms:
+                                                                name: some text
+                                                                company: some text
+                                                                city: some text
+                                                                country: some text
+                                                                state: some text
+                                                            integration: some text
+                                                            colour: RED
+                                                            matches:
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                    internal:
+                                                        -
+                                                            id: 92
+                                                            email: some text
+                                                            colour: some text
+                                                            last_name: some text
+                                                            first_name: some text
+                                                        -
+                                                            id: 44
+                                                            email: some text
+                                                            colour: some text
+                                                            last_name: some text
+                                                            first_name: some text
                                                 end_date: '2018-02-10T09:30Z'
                                                 email: some text
+                                                mobile_number: some text
                                             -
-                                                id: 46
+                                                id: 0
                                                 first_name: some text
                                                 last_name: some text
                                                 start_date: '2018-02-10T09:30Z'
                                                 location:
-                                                    id: 87
+                                                    id: 66
                                                     name: some text
-                                                watchlist_colour: ORANGE
+                                                watchlist_colour: RED
                                                 hosts:
                                                     -
-                                                        id: 4
+                                                        id: 92
                                                         email: some text
                                                         first_name: some text
                                                         last_name: some text
-                                                        mobile_number: some text
                                                         profile_pic_url: some text
+                                                        department: some text
+                                                        mobile_number: some text
                                                     -
-                                                        id: 70
+                                                        id: 85
                                                         email: some text
                                                         first_name: some text
                                                         last_name: some text
-                                                        mobile_number: some text
                                                         profile_pic_url: some text
+                                                        department: some text
+                                                        mobile_number: some text
                                                 invite_watchlist:
-                                                    id: 63
+                                                    id: 57
                                                     external_colours:
+                                                        - some text
                                                         - some text
                                                     internal_colours:
                                                         - some text
                                                         - some text
+                                                    external:
+                                                        -
+                                                            search_terms:
+                                                                name: some text
+                                                                company: some text
+                                                                city: some text
+                                                                country: some text
+                                                                state: some text
+                                                            integration: some text
+                                                            colour: GREEN
+                                                            matches:
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                        -
+                                                            search_terms:
+                                                                name: some text
+                                                                company: some text
+                                                                city: some text
+                                                                country: some text
+                                                                state: some text
+                                                            integration: some text
+                                                            colour: YELLOW
+                                                            matches:
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                                -
+                                                                    id: some text
+                                                                    alt_names:
+                                                                        - some text
+                                                                        - some text
+                                                                    federal_register_notice: some text
+                                                                    name: some text
+                                                                    source_information_url: some text
+                                                                    source_list_url: some text
+                                                                    list: some text
+                                                                    type: some text
+                                                                    category: some text
+                                                                    street1: some text
+                                                                    street2: some text
+                                                                    city: some text
+                                                                    state: some text
+                                                                    country: some text
+                                                                    notes: some text
+                                                                    frc: some text
+                                                                    start: some text
+                                                                    end: some text
+                                                                    frserve: some text
+                                                                    optional_ID: some text
+                                                                    alert_type: some text
+                                                                    pair_status: some text
+                                                                    pair_reason: some text
+                                                                    pair_comments: some text
+                                                                    application_display_name: some text
+                                                                    application_id: some text
+                                                                    client_id: some text
+                                                                    client_key: some text
+                                                                    client_full_name: some text
+                                                                    list_key: some text
+                                                                    list_name: some text
+                                                                    list_id: some text
+                                                                    list_version: some text
+                                                                    list_modify_date: some text
+                                                                    list_profile_id: some text
+                                                                    list_profile_key: some text
+                                                                    link_single_string_name: some text
+                                                                    list_parent_single_string_name: some text
+                                                                    list_category: some text
+                                                                    list_pep_category: some text
+                                                                    list_do_bs: some text
+                                                                    list_countries: some text
+                                                                    rank_string: some text
+                                                                    ranktype: some text
+                                                                    rankweight: some text
+                                                                    pair_load_date: some text
+                                                                    e_address_to: some text
+                                                                    e_address_cc: some text
+                                                                    origin: some text
+                                                                    secondsviewed: some text
+                                                                    initial_user: some text
+                                                                    is_pair_parent_flag: some text
+                                                                    pair_met_search_criteria_flag: some text
+                                                                    editable_due_to_assignment_flag: some text
+                                                                    modify_date: some text
+                                                                    modified_by_user: some text
+                                                                    pair_report_type: some text
+                                                                    finscan_category: some text
+                                                                    wrapper_status: some text
+                                                                    source_lists: some text
+                                                    internal:
+                                                        -
+                                                            id: 46
+                                                            email: some text
+                                                            colour: some text
+                                                            last_name: some text
+                                                            first_name: some text
+                                                        -
+                                                            id: 37
+                                                            email: some text
+                                                            colour: some text
+                                                            last_name: some text
+                                                            first_name: some text
                                                 end_date: '2018-02-10T09:30Z'
                                                 email: some text
+                                                mobile_number: some text
                     description: Successful response - returns an array of `Invite` entities.
                 '400':
                     content:
@@ -1793,9 +2374,9 @@ paths:
                                     last_name: some text
                                     company: some text
                                     email: some text
-                            with_registration:
+                            With Registration ID:
                                 value:
-                                    registration_id: uuid
+                                    registration_id: '123531144'
                                     guest_email_template_id: 47
                                     host_email_template_id: 65
                                     send_notifications: true
@@ -3039,18 +3620,43 @@ paths:
                                         email: some text
                                         company: some text
                                         photo_url: some text
+                                        guest_reponses:
+                                            -
+                                                title: some text
+                                                sequence: 9
+                                                id: 46
+                                                page_type: some text
+                                                custom_fields:
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
+                                            -
+                                                title: some text
+                                                sequence: 8
+                                                id: 22
+                                                page_type: some text
+                                                custom_fields:
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
+                                                    -
+                                                        field_name: some text
+                                                        field_value: some text
                                         invite:
-                                            id: 67
+                                            id: 96
                                             first_name: some text
                                             last_name: some text
                                             start_date: '2018-02-10T09:30Z'
                                             location:
-                                                id: 22
+                                                id: 95
                                                 name: some text
                                             watchlist_colour: GREEN
                                             hosts:
                                                 -
-                                                    id: 59
+                                                    id: 61
                                                     email: some text
                                                     first_name: some text
                                                     last_name: some text
@@ -3058,7 +3664,7 @@ paths:
                                                     department: some text
                                                     mobile_number: some text
                                                 -
-                                                    id: 18
+                                                    id: 57
                                                     email: some text
                                                     first_name: some text
                                                     last_name: some text
@@ -3066,7 +3672,7 @@ paths:
                                                     department: some text
                                                     mobile_number: some text
                                             invite_watchlist:
-                                                id: 65
+                                                id: 7
                                                 external_colours:
                                                     - some text
                                                     - some text
@@ -3077,7 +3683,7 @@ paths:
                                             email: some text
                                             mobile_number: some text
                                         visitor:
-                                            id: some text
+                                            id: 7
                                             active: true
                                             company: some text
                                             created_via: some text
@@ -3093,31 +3699,6 @@ paths:
                                             watchlist_level: some text
                                             created_at: '2018-02-10T09:30Z'
                                             updated_at: '2018-02-10T09:30Z'
-                                        guest_responses:
-                                            -
-                                                title: some text
-                                                sequence: 17
-                                                id: some text
-                                                page_type: branch_page
-                                                custom_fields:
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
-                                            -
-                                                title: some text
-                                                sequence: 29
-                                                id: some text
-                                                page_type: docusign_page
-                                                custom_fields:
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
-                                                    -
-                                                        field_name: some text
-                                                        field_value: some text
                     description: Successful response - returns a single `Registration`.
                 '400':
                     content:
@@ -4455,7 +5036,6 @@ components:
                                 - some text
                         end_date: '2018-02-10T09:30Z'
         SigninCreateParams:
-            description: Params used to create a Signin
             required: []
             type: object
             properties:
@@ -4464,7 +5044,7 @@ components:
                 host_email_template_id:
                     type: integer
                 host_ids:
-                    description: 'Array of Host ids, ignored if `registration_id` is included'
+                    description: 'Array of Hosts, ignored if `registration_id` is included'
                     type: array
                     items:
                         type: integer
@@ -4472,7 +5052,6 @@ components:
                     description: 'ID of the Location where the Signin happened, ignored if `registration_id` is included'
                     type: integer
                 send_notifications:
-                    description: Should send notification to host/guests?
                     type: boolean
                 sms_message:
                     type: string
@@ -4559,6 +5138,16 @@ components:
                     type: array
                     items:
                         type: string
+                external:
+                    description: ''
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ExternalWatchlistResult'
+                internal:
+                    description: ''
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/InternalWatchlistResult'
             example:
                 id: 4
                 external_colours:
@@ -4567,6 +5156,292 @@ components:
                 internal_colours:
                     - YELLOW
                     - GREEN
+                external:
+                    -
+                        search_terms:
+                            name: some text
+                            company: some text
+                            city: some text
+                            country: some text
+                            state: some text
+                        integration: some text
+                        colour: YELLOW
+                        matches:
+                            -
+                                id: some text
+                                alt_names:
+                                    - some text
+                                    - some text
+                                federal_register_notice: some text
+                                name: some text
+                                source_information_url: some text
+                                source_list_url: some text
+                                list: some text
+                                type: some text
+                                category: some text
+                                street1: some text
+                                street2: some text
+                                city: some text
+                                state: some text
+                                country: some text
+                                notes: some text
+                                frc: some text
+                                start: some text
+                                end: some text
+                                frserve: some text
+                                optional_ID: some text
+                                alert_type: some text
+                                pair_status: some text
+                                pair_reason: some text
+                                pair_comments: some text
+                                application_display_name: some text
+                                application_id: some text
+                                client_id: some text
+                                client_key: some text
+                                client_full_name: some text
+                                list_key: some text
+                                list_name: some text
+                                list_id: some text
+                                list_version: some text
+                                list_modify_date: some text
+                                list_profile_id: some text
+                                list_profile_key: some text
+                                link_single_string_name: some text
+                                list_parent_single_string_name: some text
+                                list_category: some text
+                                list_pep_category: some text
+                                list_do_bs: some text
+                                list_countries: some text
+                                rank_string: some text
+                                ranktype: some text
+                                rankweight: some text
+                                pair_load_date: some text
+                                e_address_to: some text
+                                e_address_cc: some text
+                                origin: some text
+                                secondsviewed: some text
+                                initial_user: some text
+                                is_pair_parent_flag: some text
+                                pair_met_search_criteria_flag: some text
+                                editable_due_to_assignment_flag: some text
+                                modify_date: some text
+                                modified_by_user: some text
+                                pair_report_type: some text
+                                finscan_category: some text
+                                wrapper_status: some text
+                                source_lists: some text
+                            -
+                                id: some text
+                                alt_names:
+                                    - some text
+                                    - some text
+                                federal_register_notice: some text
+                                name: some text
+                                source_information_url: some text
+                                source_list_url: some text
+                                list: some text
+                                type: some text
+                                category: some text
+                                street1: some text
+                                street2: some text
+                                city: some text
+                                state: some text
+                                country: some text
+                                notes: some text
+                                frc: some text
+                                start: some text
+                                end: some text
+                                frserve: some text
+                                optional_ID: some text
+                                alert_type: some text
+                                pair_status: some text
+                                pair_reason: some text
+                                pair_comments: some text
+                                application_display_name: some text
+                                application_id: some text
+                                client_id: some text
+                                client_key: some text
+                                client_full_name: some text
+                                list_key: some text
+                                list_name: some text
+                                list_id: some text
+                                list_version: some text
+                                list_modify_date: some text
+                                list_profile_id: some text
+                                list_profile_key: some text
+                                link_single_string_name: some text
+                                list_parent_single_string_name: some text
+                                list_category: some text
+                                list_pep_category: some text
+                                list_do_bs: some text
+                                list_countries: some text
+                                rank_string: some text
+                                ranktype: some text
+                                rankweight: some text
+                                pair_load_date: some text
+                                e_address_to: some text
+                                e_address_cc: some text
+                                origin: some text
+                                secondsviewed: some text
+                                initial_user: some text
+                                is_pair_parent_flag: some text
+                                pair_met_search_criteria_flag: some text
+                                editable_due_to_assignment_flag: some text
+                                modify_date: some text
+                                modified_by_user: some text
+                                pair_report_type: some text
+                                finscan_category: some text
+                                wrapper_status: some text
+                                source_lists: some text
+                    -
+                        search_terms:
+                            name: some text
+                            company: some text
+                            city: some text
+                            country: some text
+                            state: some text
+                        integration: some text
+                        colour: YELLOW
+                        matches:
+                            -
+                                id: some text
+                                alt_names:
+                                    - some text
+                                    - some text
+                                federal_register_notice: some text
+                                name: some text
+                                source_information_url: some text
+                                source_list_url: some text
+                                list: some text
+                                type: some text
+                                category: some text
+                                street1: some text
+                                street2: some text
+                                city: some text
+                                state: some text
+                                country: some text
+                                notes: some text
+                                frc: some text
+                                start: some text
+                                end: some text
+                                frserve: some text
+                                optional_ID: some text
+                                alert_type: some text
+                                pair_status: some text
+                                pair_reason: some text
+                                pair_comments: some text
+                                application_display_name: some text
+                                application_id: some text
+                                client_id: some text
+                                client_key: some text
+                                client_full_name: some text
+                                list_key: some text
+                                list_name: some text
+                                list_id: some text
+                                list_version: some text
+                                list_modify_date: some text
+                                list_profile_id: some text
+                                list_profile_key: some text
+                                link_single_string_name: some text
+                                list_parent_single_string_name: some text
+                                list_category: some text
+                                list_pep_category: some text
+                                list_do_bs: some text
+                                list_countries: some text
+                                rank_string: some text
+                                ranktype: some text
+                                rankweight: some text
+                                pair_load_date: some text
+                                e_address_to: some text
+                                e_address_cc: some text
+                                origin: some text
+                                secondsviewed: some text
+                                initial_user: some text
+                                is_pair_parent_flag: some text
+                                pair_met_search_criteria_flag: some text
+                                editable_due_to_assignment_flag: some text
+                                modify_date: some text
+                                modified_by_user: some text
+                                pair_report_type: some text
+                                finscan_category: some text
+                                wrapper_status: some text
+                                source_lists: some text
+                            -
+                                id: some text
+                                alt_names:
+                                    - some text
+                                    - some text
+                                federal_register_notice: some text
+                                name: some text
+                                source_information_url: some text
+                                source_list_url: some text
+                                list: some text
+                                type: some text
+                                category: some text
+                                street1: some text
+                                street2: some text
+                                city: some text
+                                state: some text
+                                country: some text
+                                notes: some text
+                                frc: some text
+                                start: some text
+                                end: some text
+                                frserve: some text
+                                optional_ID: some text
+                                alert_type: some text
+                                pair_status: some text
+                                pair_reason: some text
+                                pair_comments: some text
+                                application_display_name: some text
+                                application_id: some text
+                                client_id: some text
+                                client_key: some text
+                                client_full_name: some text
+                                list_key: some text
+                                list_name: some text
+                                list_id: some text
+                                list_version: some text
+                                list_modify_date: some text
+                                list_profile_id: some text
+                                list_profile_key: some text
+                                link_single_string_name: some text
+                                list_parent_single_string_name: some text
+                                list_category: some text
+                                list_pep_category: some text
+                                list_do_bs: some text
+                                list_countries: some text
+                                rank_string: some text
+                                ranktype: some text
+                                rankweight: some text
+                                pair_load_date: some text
+                                e_address_to: some text
+                                e_address_cc: some text
+                                origin: some text
+                                secondsviewed: some text
+                                initial_user: some text
+                                is_pair_parent_flag: some text
+                                pair_met_search_criteria_flag: some text
+                                editable_due_to_assignment_flag: some text
+                                modify_date: some text
+                                modified_by_user: some text
+                                pair_report_type: some text
+                                finscan_category: some text
+                                wrapper_status: some text
+                                source_lists: some text
+                internal:
+                    -
+                        id: 55
+                        email: some text
+                        colour: some text
+                        last_name: some text
+                        first_name: some text
+                    -
+                        id: 60
+                        email: some text
+                        colour: some text
+                        last_name: some text
+                        first_name: some text
         InviteCreateParams:
             title: Root Type for InviteCreateParams
             description: The root of the InviteCreateParams type's schema.
@@ -5730,17 +6605,17 @@ components:
                 photo_url:
                     description: URL of the uploaded photo
                     type: string
+                guest_reponses:
+                    description: Response given by the guest
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/GuestResponse'
                 invite:
                     $ref: '#/components/schemas/Invite'
                     description: Invite it belongs to
                 visitor:
                     $ref: '#/components/schemas/Visitor'
                     description: Visitor
-                guest_responses:
-                    description: Response given by the guest
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/GuestResponse'
             example:
                 id: uuid
                 created_at: '2018-02-10T09:30Z'
@@ -5748,18 +6623,43 @@ components:
                 email: some text
                 company: some text
                 photo_url: some text
+                guest_reponses:
+                    -
+                        title: some text
+                        sequence: 69
+                        id: 36
+                        page_type: some text
+                        custom_fields:
+                            -
+                                field_name: some text
+                                field_value: some text
+                            -
+                                field_name: some text
+                                field_value: some text
+                    -
+                        title: some text
+                        sequence: 64
+                        id: 20
+                        page_type: some text
+                        custom_fields:
+                            -
+                                field_name: some text
+                                field_value: some text
+                            -
+                                field_name: some text
+                                field_value: some text
                 invite:
-                    id: 51
+                    id: 39
                     first_name: some text
                     last_name: some text
                     start_date: '2018-02-10T09:30Z'
                     location:
-                        id: 67
+                        id: 21
                         name: some text
-                    watchlist_colour: YELLOW
+                    watchlist_colour: GREEN
                     hosts:
                         -
-                            id: 23
+                            id: 16
                             email: some text
                             first_name: some text
                             last_name: some text
@@ -5767,7 +6667,7 @@ components:
                             department: some text
                             mobile_number: some text
                         -
-                            id: 23
+                            id: 92
                             email: some text
                             first_name: some text
                             last_name: some text
@@ -5775,7 +6675,7 @@ components:
                             department: some text
                             mobile_number: some text
                     invite_watchlist:
-                        id: 70
+                        id: 91
                         external_colours:
                             - some text
                             - some text
@@ -5786,7 +6686,7 @@ components:
                     email: some text
                     mobile_number: some text
                 visitor:
-                    id: some text
+                    id: 20
                     active: true
                     company: some text
                     created_via: some text
@@ -5802,31 +6702,6 @@ components:
                     watchlist_level: some text
                     created_at: '2018-02-10T09:30Z'
                     updated_at: '2018-02-10T09:30Z'
-                guest_responses:
-                    -
-                        title: some text
-                        sequence: 43
-                        id: some text
-                        page_type: video_page
-                        custom_fields:
-                            -
-                                field_name: some text
-                                field_value: some text
-                            -
-                                field_name: some text
-                                field_value: some text
-                    -
-                        title: some text
-                        sequence: 35
-                        id: some text
-                        page_type: guest_sign_page
-                        custom_fields:
-                            -
-                                field_name: some text
-                                field_value: some text
-                            -
-                                field_name: some text
-                                field_value: some text
         GuestResponse:
             title: Root Type for GuestResponse
             description: The data collected from the response on a Registration

--- a/openapi.yml
+++ b/openapi.yml
@@ -5044,7 +5044,7 @@ components:
                 host_email_template_id:
                     type: integer
                 host_ids:
-                    description: 'Array of Hosts, ignored if `registration_id` is included'
+                    description: 'Array of Host ids, ignored if `registration_id` is included'
                     type: array
                     items:
                         type: integer


### PR DESCRIPTION
### Wrike: ###
Backend: Return watchlist data
https://www.wrike.com/open.htm?id=493269014

### Description: ###
Add `external` and `internal` nodes on `invite_watchlist` and deprecate `external_colours` and `internal_colours`
```
{
    "id": 4,
    "external_colours": [
        "RED",
        "ORANGE"
    ],
    "internal_colours": [
        "YELLOW",
        "GREEN"
    ],
    "external": [{}, {}, {}],
    "internal": [{}, {}, {}]
}
```

### PR Checklist ###

- [x] Assigned 2 or more reviewers
- [x] Added yourself as "Assignee"
- [x] Included labels such as "WIP", "Waiting for reviews", etc.
