### PR TITLE
[#507021867] Revert GH actions runner

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -2,7 +2,7 @@ name: 'Auto Assign'
 on: pull_request
 jobs:
   add-reviews:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v1.1.0
         with:


### PR DESCRIPTION
### Description
Revert the GH actions to use the non self-hosted runner because of security issues with using those on public repos.