### PR TITLE
[#531700912] Renamed Capacity endpoints

### DIFF
--- a/models/Capacity.v1.yaml
+++ b/models/Capacity.v1.yaml
@@ -1,4 +1,4 @@
-title: CapacitySummary
+title: Capacity
 type: object
 x-tags:
   - Capacities
@@ -11,4 +11,4 @@ properties:
     type: integer
   invites_expected_next_hour:
     type: integer
-description: "The root of the CapacitySummary's schema."
+description: "The root of the Capacity's schema."

--- a/models/CapacityForecast.v1.yaml
+++ b/models/CapacityForecast.v1.yaml
@@ -1,4 +1,4 @@
-title: CapacityResponse
+title: CapacityForecast
 type: object
 x-examples:
   default:
@@ -27,7 +27,7 @@ x-examples:
       - range_start: '2020-07-17T07:59:59.999Z'
         range_end: '2020-07-17T08:59:59.999Z'
         expected_visitors: 1
-description: "The root of the CapacityResponse's schema."
+description: "The root of the CapacityForecast's schema."
 properties:
   invites_by_hour:
     type: array

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Traction Guest API
-  version: 0.12.0
+  version: 0.12.1
   description: |
     The Traction Guest API is currently in **closed beta**.
     We're still building, testing, and fixing bugs.

--- a/openapi.yml
+++ b/openapi.yml
@@ -3543,7 +3543,7 @@ paths:
           description: You do not have permission for this action
         '404':
           description: The Location does not exist
-      operationId: GetLocation
+      operationId: getLocation
       description: Gets details of a single instance of `Location`.
 components:
   parameters:

--- a/openapi.yml
+++ b/openapi.yml
@@ -3387,7 +3387,7 @@ paths:
           in: query
           name: created_after
           description: Restricts results to only those that were created after the provided date
-  '/locations/{location_id}/capacities':
+  '/locations/{location_id}/capacity_forecasts':
     parameters:
       - schema:
           type: string
@@ -3404,7 +3404,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ./models/CapacityResponse.v1.yaml
+                $ref: ./models/CapacityForecast.v1.yaml
               examples:
                 default:
                   value:
@@ -3464,14 +3464,14 @@ paths:
             maximum: 24
             default: 8
           in: query
-          name: hours_to_calculate
+          name: hours_to_forecast
           description: 'The next N number of hours, the data needs to be calculated. Range from 1 to 24. If not set, it defaults to 8.'
         - schema:
             type: string
           in: query
           name: timestamp
           description: 'ISO8601 timestamp(includes the offset value) to use as the start point for the capacity estimate report. Defaults to the current local timestamp of the location if not provided. Eg: "2020-07-16T17:05:08-07:00"'
-  '/locations/{location_id}/capacity_summaries':
+  '/locations/{location_id}/capacities':
     parameters:
       - schema:
           type: string
@@ -3488,7 +3488,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ./models/CapacitySummary.v1.yaml
+                $ref: ./models/Capacity.v1.yaml
               examples:
                 default:
                   value:

--- a/openapi.yml
+++ b/openapi.yml
@@ -3506,6 +3506,45 @@ paths:
           description: You do not have permission for this action
       operationId: getLocationCapacitySummary
       description: Get details of current capacity in a location
+  '/locations/{location_id}':
+    parameters:
+      - schema:
+          type: string
+        name: location_id
+        in: path
+        required: true
+    get:
+      summary: Get the details of a location
+      tags:
+        - Locations
+      responses:
+        '200':
+          description: Successful response - returns a single `Location`.
+          content:
+            application/json:
+              schema:
+                $ref: ./models/Location.v1.yaml
+              examples:
+                default:
+                  value:
+                    id: 1
+                    name: Default
+                    max_capacity: 30
+                    timezone: America/Vancouver
+        '400':
+          description: A generic error
+          content:
+            application/json:
+              schema:
+                $ref: ./models/ErrorsList.v1.yaml
+        '401':
+          description: "You don't have permission to view this Location"
+        '403':
+          description: You do not have permission for this action
+        '404':
+          description: The Location does not exist
+      operationId: GetLocation
+      description: Gets details of a single instance of `Location`.
 components:
   parameters:
     idempotencyKey:


### PR DESCRIPTION
### Description
Renamed endpoints of capacity management,

**/locations/{location_id}/capacities** - the endpoint the get the current number of signins, and invites expected soon,
**/locations/{location_id}/capacity_forecasts**- the endpoint that would give the data on invites expected over time 
renamed _hours_to_calculate_ param to _hours_to_forecast_

Added new endpoint - locations/{location_id}

### Changelog
- Write which paths/models/etc. are being modified so people know what to pay attention to
