### PR TITLE
[#531700912] Added 401 responses capacity

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Traction Guest API
-  version: 0.12.2
+  version: 0.12.3
   description: |
     The Traction Guest API is currently in **closed beta**.
     We're still building, testing, and fixing bugs.
@@ -886,6 +886,10 @@ paths:
           description: A generic error
         '401':
           description: "You don't have permission to view these Locations"
+          content:
+            application/json:
+              schema:
+                $ref: ./models/ErrorsList.v1.yaml
         '403':
           description: You do not have permission for this action
       operationId: getLocations
@@ -3453,6 +3457,10 @@ paths:
                         message: some text
         '401':
           description: "You don't have permission to view the details of the location's capacity."
+          content:
+            application/json:
+              schema:
+                $ref: ./models/ErrorsList.v1.yaml
         '403':
           description: You do not have permission for this action
       operationId: getCapacityForecast
@@ -3502,6 +3510,10 @@ paths:
                 $ref: ./models/ErrorsList.v1.yaml
         '401':
           description: "You don't have permission to view the details of the location's capacity."
+          content:
+            application/json:
+              schema:
+                $ref: ./models/ErrorsList.v1.yaml
         '403':
           description: You do not have permission for this action
       operationId: getCapacity
@@ -3537,8 +3549,13 @@ paths:
             application/json:
               schema:
                 $ref: ./models/ErrorsList.v1.yaml
+              examples: {}
         '401':
           description: "You don't have permission to view this Location"
+          content:
+            application/json:
+              schema:
+                $ref: ./models/ErrorsList.v1.yaml
         '403':
           description: You do not have permission for this action
         '404':

--- a/openapi.yml
+++ b/openapi.yml
@@ -2,6 +2,11 @@ openapi: 3.0.2
 info:
   title: Traction Guest API
   version: 0.12.3
+  x-logo:
+    url: "https://tractionguest.com/wp-content/uploads/tg-logo-light@2.png"
+    backgroundColor: "#FFFFFF"
+    altText: "Traction Guest logo"
+    href: "https://tractionguest.com"
   description: |
     The Traction Guest API is currently in **closed beta**.
     We're still building, testing, and fixing bugs.

--- a/openapi.yml
+++ b/openapi.yml
@@ -3622,3 +3622,5 @@ tags:
     description: All endpoints related to the AuditLog model.
   - name: Registration
     description: All endpoints related to the Registration model.
+  - name: Capacities
+    description: All endpoints related to the Capacity model.


### PR DESCRIPTION
### Description

Added 401 response body for the following endpoints,
1. api/v3/locations
2. api/v3/locations/{location_id}
3. api/v3/locations/{location_id}/capacity_forecasts
4. api/v3/locations/{location_id}/capacities

Added 401 responses, because contract tracing breaks saying no response added for 401 response. The spec with invalid_authentication_header uses this response.

Added Capacities as Global tag

### Changelog
- Write which paths/models/etc. are being modified so people know what to pay attention to
